### PR TITLE
Fix: Correct syntax for checking secrets in workflow condition

### DIFF
--- a/.github/workflows/selenium-tests.yml
+++ b/.github/workflows/selenium-tests.yml
@@ -163,7 +163,7 @@ jobs:
       - name: Send Allure Report Email
         # Send email only if the test job itself succeeded or failed (not cancelled/skipped)
         # and if SMTP secrets are likely configured (simple check if not empty).
-        if: (needs.test.result == 'success' || needs.test.result == 'failure') && ${{ secrets.SMTP_USERNAME != '' }} && ${{ secrets.SMTP_PASSWORD != '' }}
+        if: ${{ (needs.test.result == 'success' || needs.test.result == 'failure') && secrets.SMTP_USERNAME != '' && secrets.SMTP_PASSWORD != '' }}
         uses: dawidd6/action-send-mail@v3
         with:
           server_address: smtp.gmail.com


### PR DESCRIPTION
The `if` condition for the email sending step in the selenium-tests.yml workflow was using an incorrect syntax to check for the existence of secrets. This caused a workflow validation error: "Unrecognized named-value: 'secrets'".

This commit fixes the issue by wrapping the entire conditional expression within `${{ ... }}`, ensuring that the expression parser correctly evaluates the check for `secrets.SMTP_USERNAME` and `secrets.SMTP_PASSWORD`.

The corrected line is:
`if: ${{ (needs.test.result == 'success' || needs.test.result == 'failure') && secrets.SMTP_USERNAME != '' && secrets.SMTP_PASSWORD != '' }}`