### PR TITLE
Fix: Correct typo in selenium-tests.yml workflow

### DIFF
--- a/.github/workflows/selenium-tests.yml
+++ b/.github/workflows/selenium-tests.yml
@@ -1,4 +1,4 @@
-ame: CI with Dynamic Allure Report and Email
+name: CI with Dynamic Allure Report and Email
 
 #  'on' block
 on:


### PR DESCRIPTION
The workflow file .github/workflows/selenium-tests.yml had a typo on the first line, where `ame:` was used instead of `name:`. This commit corrects the typo.