### PR TITLE
Add docker-compose.yml for Selenium Grid

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3'
+services:
+  selenium-hub:
+    image: selenium/hub:4.8.0-20230103
+    container_name: selenium-hub
+    ports:
+      - "4444:4444"
+  chrome-node:
+    image: selenium/node-chrome:4.8.0-20230103
+    depends_on:
+      - selenium-hub
+    environment:
+      - SE_EVENT_BUS_HOST=selenium-hub
+      - SE_EVENT_BUS_PUBLISH_PORT=4442
+      - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
+  firefox-node:
+    image: selenium/node-firefox:4.8.0-20230103
+    depends_on:
+      - selenium-hub
+    environment:
+      - SE_EVENT_BUS_HOST=selenium-hub
+      - SE_EVENT_BUS_PUBLISH_PORT=4442
+      - SE_EVENT_BUS_SUBSCRIBE_PORT=4443


### PR DESCRIPTION
This commit introduces a docker-compose.yml file to set up a Selenium Grid. The setup includes:
- A Selenium Hub (selenium/hub:4.8.0-20230103) exposing port 4444.
- A Chrome node (selenium/node-chrome:4.8.0-20230103) registered to the hub.
- A Firefox node (selenium/node-firefox:4.8.0-20230103) registered to the hub.