### PR TITLE
feat: Add remote WebDriver support to conftest.py

### DIFF
--- a/Tests/conftest.py
+++ b/Tests/conftest.py
@@ -15,6 +15,8 @@ def pytest_addoption(parser):
     """
     parser.addoption("--browser", default="chrome",
                      help="Browser to run tests: chrome, firefox, edge, safari")
+    parser.addoption("--remote-url", default=None,
+                     help="Remote Selenium Grid URL (e.g., http://localhost:4444/wd/hub)")
 
 @pytest.fixture(scope="session")
 def browser_name(request):
@@ -48,36 +50,64 @@ def base_url():
     return "https://www.saucedemo.com/"
 
 @pytest.fixture(scope='function')
-def driver(browser_name):
-    """Initialize and configure the WebDriver based on browser selection"""
+def driver(browser_name, request): # Added 'request'
+    """Initialize and configure the WebDriver based on browser selection and remote URL."""
+    remote_url = request.config.getoption("--remote-url")
     is_ci = os.environ.get('CI') == 'true' or os.environ.get('GITHUB_ACTIONS') == 'true'
 
-    if browser_name == "chrome":
-        options = ChromeOptions()
-        if is_ci:
-            options.add_argument("--headless")
-            options.add_argument("--no-sandbox")
-            options.add_argument("--disable-dev-shm-usage")
-            options.add_argument("--disable-gpu")
-            options.add_argument("--window-size=1920,1080")
-        driver = webdriver.Chrome(options=options)
-    elif browser_name == "firefox":
-        options = FirefoxOptions()
-        if is_ci:
-            options.add_argument("--headless")
-        driver = webdriver.Firefox(options=options)
-    elif browser_name == "edge":
-        options = EdgeOptions()
-        if is_ci:
-            options.add_argument("--headless")
-        driver = webdriver.Edge(options=options)
-    elif browser_name == "safari":
-        # Safari options for headless are not standard/widely supported like others
-        # It usually runs headful, WebDriver will use default Safari settings.
-        # If running in CI without a GUI, Safari might not work or require specific setup.
-        driver = webdriver.Safari()
+    if remote_url:
+        # Logic for remote driver
+        if browser_name == "chrome":
+            options = ChromeOptions()
+            if is_ci: # Apply CI options if needed for remote too
+                options.add_argument("--headless")
+                options.add_argument("--no-sandbox")
+                options.add_argument("--disable-dev-shm-usage")
+                options.add_argument("--disable-gpu")
+                options.add_argument("--window-size=1920,1080")
+        elif browser_name == "firefox":
+            options = FirefoxOptions()
+            if is_ci:
+                options.add_argument("--headless")
+        elif browser_name == "edge":
+            options = EdgeOptions()
+            if is_ci:
+                options.add_argument("--headless")
+        elif browser_name == "safari":
+            options = SafariOptions()
+            # Safari doesn't typically support headless in the same way
+            # and might not need specific CI options for remote execution.
+        else:
+            raise ValueError(f"Unsupported browser for remote execution: {browser_name}")
+
+        # Common capabilities/options setup for remote driver can go here if needed
+        # For Selenium 4, desired_capabilities is deprecated for Remote. Options object is preferred.
+        driver = webdriver.Remote(command_executor=remote_url, options=options)
     else:
-        raise ValueError(f"Unsupported browser: {browser_name}")
+        # Existing local driver logic
+        if browser_name == "chrome":
+            options = ChromeOptions()
+            if is_ci:
+                options.add_argument("--headless")
+                options.add_argument("--no-sandbox")
+                options.add_argument("--disable-dev-shm-usage")
+                options.add_argument("--disable-gpu")
+                options.add_argument("--window-size=1920,1080")
+            driver = webdriver.Chrome(options=options)
+        elif browser_name == "firefox":
+            options = FirefoxOptions()
+            if is_ci:
+                options.add_argument("--headless")
+            driver = webdriver.Firefox(options=options)
+        elif browser_name == "edge":
+            options = EdgeOptions()
+            if is_ci:
+                options.add_argument("--headless")
+            driver = webdriver.Edge(options=options)
+        elif browser_name == "safari":
+            driver = webdriver.Safari()
+        else:
+            raise ValueError(f"Unsupported browser: {browser_name}")
 
     driver.maximize_window()
     driver.implicitly_wait(10)


### PR DESCRIPTION
This commit introduces the following changes to `Tests/conftest.py`:

- Added a `--remote-url` command-line option to pytest. This allows specifying a URL for a remote Selenium Grid.
- Modified the `driver` fixture:
    - If `--remote-url` is provided, the fixture now initializes a `webdriver.Remote` instance, configured with the specified URL and appropriate browser options.
    - If `--remote-url` is not provided, the fixture falls back to the existing logic of initializing a local WebDriver (Chrome, Firefox, Edge, Safari).
- Ensured that browser-specific options (including CI-specific arguments like headless mode) are correctly applied for both local and remote WebDriver scenarios.
- Verified that all necessary imports are present and the driver quitting mechanism remains robust.

These changes enable tests to be run against a remote Selenium Grid, providing flexibility for distributed testing environments.