### PR TITLE
Fix: Correct service configuration in CI workflow

### DIFF
--- a/.github/workflows/selenium-grid-ci.yml
+++ b/.github/workflows/selenium-grid-ci.yml
@@ -35,9 +35,7 @@ jobs:
           - 4444:4444
       node-chrome:
         image: selenium/node-chrome:4.18.1-20240224
-        depends_on:
-          - selenium-hub
-        environment:
+        env:
           SE_EVENT_BUS_HOST: selenium-hub
           SE_EVENT_BUS_PUBLISH_PORT: 4442
           SE_EVENT_BUS_SUBSCRIBE_PORT: 4443
@@ -45,9 +43,7 @@ jobs:
           # SHM_SIZE: "2g"
       node-firefox:
         image: selenium/node-firefox:4.18.1-20240224
-        depends_on:
-          - selenium-hub
-        environment:
+        env:
           SE_EVENT_BUS_HOST: selenium-hub
           SE_EVENT_BUS_PUBLISH_PORT: 4442
           SE_EVENT_BUS_SUBSCRIBE_PORT: 4443


### PR DESCRIPTION
Updated the .github/workflows/selenium-grid-ci.yml file to address issues with service definitions:

- Removed `depends_on` from `node-chrome` and `node-firefox` services as GitHub Actions starts all services concurrently by default.
- Changed `environment:` to `env:` for both `node-chrome` and `node-firefox` services to use the correct YAML mapping syntax for defining environment variables for services in GitHub Actions.

These changes ensure the workflow adheres to the valid syntax for service configurations, resolving CI failures related to these keys.