### PR TITLE
Fix: Correct CI workflow failures

### DIFF
--- a/.github/workflows/selenium-grid-ci.yml
+++ b/.github/workflows/selenium-grid-ci.yml
@@ -55,6 +55,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
       - name: Pull test framework image
         run: docker pull myorg/test-framework:latest
 


### PR DESCRIPTION
The CI workflow was failing due to two main issues:
1. Inability to pull the `myorg/test-framework:latest` Docker image.
2. GitHub Pages deployment failures.

This commit addresses these issues by:
- Adding a step to log in to Docker Hub using `docker/login-action@v3` before attempting to pull the test framework image. This requires `DOCKER_USERNAME` and `DOCKER_PASSWORD` secrets to be configured in your repository.
- Verifying that the GitHub Pages deployment steps are correctly configured. The deployment failures were likely a consequence of the image pull failure, which prevented test execution and report generation.

With these changes, and assuming you have the necessary secrets in place, the workflow should now be able to pull the Docker image, execute tests, generate the Allure report, and deploy it to GitHub Pages.