### PR TITLE
Fix: Configure deployment environment for GitHub Pages

### DIFF
--- a/.github/workflows/selenium-grid-ci.yml
+++ b/.github/workflows/selenium-grid-ci.yml
@@ -26,6 +26,9 @@ jobs:
     permissions:
       pages: write      # Required to deploy to GitHub Pages
       id-token: write   # Required for OIDC token authentication with GitHub Pages
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
 
     services:
       # Selenium Grid Services: Hub and browser nodes


### PR DESCRIPTION
I've added the explicit `environment` configuration to the `ci` job for the GitHub Pages deployment. This aligns with best practices recommended by the `actions/deploy-pages` documentation.

This change aims to improve the reliability of the Pages deployment by clearly defining the target environment and its URL source.